### PR TITLE
[MED-0000] Add watchtower to watch for image pushes

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,7 @@
+version: "3"
 services:
   frontend:
+    image: ecofreshkaese/medals-frontend:latest
     build:
       context: .
       dockerfile: frontend.Dockerfile
@@ -7,6 +9,16 @@ services:
       - "1024:80"
     depends_on:
       - backend
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
 
   backend:
     image: ecofreshkaese/medals-backend:latest
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 30 --label-enable --cleanup


### PR DESCRIPTION
This PR adds an watchtower service to the deployment that automatically pulls changes on the ecofreshkaese/medals-frontend and ecofreshkaese/medals-backend images and restarts the frontend and backend services.

This decouples our automatic deployment from the Workflow runs, because we can omit the ssh-ing to deploy on the server in the frontend and backend workflows. 